### PR TITLE
Issue N/A: Flush DrawablePool to GPU only once

### DIFF
--- a/Source/Azura/RenderSystem/Src/Vulkan/VkDrawablePool.cpp
+++ b/Source/Azura/RenderSystem/Src/Vulkan/VkDrawablePool.cpp
@@ -328,6 +328,16 @@ void VkDrawablePool::Submit() {
   VkCore::CreateCommandBuffers(m_device, m_graphicsCommandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY, m_commandBuffers,
                                log_VulkanRenderSystem);
 
+  // Flush Entire Staging Buffer to GPU
+  UNUSED(m_stagingBuffer.MapMemory(m_mainBufferOffset, 0));
+  VkMappedMemoryRange currentRange = {};
+  currentRange.sType = VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE;
+  currentRange.memory = m_stagingBuffer.Memory();
+  currentRange.size = VK_WHOLE_SIZE;
+  currentRange.offset = 0;
+  vkFlushMappedMemoryRanges(m_device, 1, &currentRange);
+  m_stagingBuffer.UnMapMemory();
+
   VkCore::CopyBuffer(m_device, m_graphicsQueue, m_stagingBuffer, m_buffer, m_mainBufferOffset, m_graphicsCommandPool);
 
   SubmitTextureData();

--- a/Source/Azura/RenderSystem/Src/Vulkan/VkRenderer.cpp
+++ b/Source/Azura/RenderSystem/Src/Vulkan/VkRenderer.cpp
@@ -216,7 +216,7 @@ DrawablePool& VkRenderer::CreateDrawablePool(const DrawablePoolCreateInfo& creat
   VkDrawablePool pool = VkDrawablePool(createInfo, m_device, m_graphicsQueue,
                                        VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT |
                                        VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                                       VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
                                        m_graphicsCommandPool,
                                        m_pipelineLayout, m_descriptorPool, m_descriptorSetLayouts,
                                        m_renderPasses, m_renderPassAttachmentImages, m_shaders,


### PR DESCRIPTION
Changes:
fix: minor changes to API to flush data to GPU only once instead of
doing every single update to the stagingBuffer

Modules:
VulkanRenderSystem