### PR TITLE
Expose API to update render target at init

### DIFF
--- a/Source/Azura/RenderSystem/Inc/D3D12/D3D12Renderer.h
+++ b/Source/Azura/RenderSystem/Inc/D3D12/D3D12Renderer.h
@@ -43,6 +43,8 @@ public:
 
   void SnapshotFrame(const String& exportPath) const override;
 
+  void BindRenderTarget(U32 renderTargetId, const TextureDesc& desc, const U8* buffer) override;
+
 private:
   void AddShader(const ShaderCreateInfo& info) override;
 
@@ -68,6 +70,10 @@ private:
   CD3DX12_RECT m_scissorRect;
 
   D3D12ScopedImage m_depthTexture{};
+
+  D3D12ScopedBuffer m_stagingBuffer;
+
+  Containers::Vector<TextureBufferInfo> m_renderTargetUpdates;
 
   Containers::Vector<std::pair<U32, RenderPassType>> m_renderSequence;
 

--- a/Source/Azura/RenderSystem/Inc/Generic/GenericTypes.h
+++ b/Source/Azura/RenderSystem/Inc/Generic/GenericTypes.h
@@ -363,7 +363,12 @@ constexpr U32 MAX_RENDER_PASS_OUTPUTS  = 4;
 constexpr U32 MAX_RENDER_PASS_SETS     = 8;
 constexpr U32 MAX_RENDER_PASS_SHADERS  = 4;
 
+struct MemoryRequirements {
+  U32 m_stagingBufferSize{0x4000000};
+};
+
 struct ApplicationRequirements {
+  MemoryRequirements m_renderer;
 };
 
 struct SwapChainRequirements {

--- a/Source/Azura/RenderSystem/Inc/Generic/Renderer.h
+++ b/Source/Azura/RenderSystem/Inc/Generic/Renderer.h
@@ -44,6 +44,8 @@ public:
 
   virtual void SnapshotFrame(const String& exportPath) const = 0;
 
+  virtual void BindRenderTarget(U32 renderTargetId, const TextureDesc& desc, const U8* buffer) = 0;
+
 protected:
   const ApplicationInfo& GetApplicationInfo() const;
   const DeviceRequirements& GetDeviceRequirements() const;

--- a/Source/Azura/RenderSystem/Inc/Vulkan/VkRenderer.h
+++ b/Source/Azura/RenderSystem/Inc/Vulkan/VkRenderer.h
@@ -54,6 +54,8 @@ public:
 
   void SnapshotFrame(const String& exportPath) const override;
 
+  void BindRenderTarget(U32 renderTargetId, const TextureDesc& desc, const U8* buffer) override;
+
 private:
   void AddShader(const ShaderCreateInfo& info) override;
 

--- a/Source/Azura/RenderSystem/Src/Vulkan/VkRenderer.cpp
+++ b/Source/Azura/RenderSystem/Src/Vulkan/VkRenderer.cpp
@@ -648,6 +648,12 @@ void VkRenderer::SnapshotFrame(const String& exportPath) const {
     height);
 }
 
+void VkRenderer::BindRenderTarget(U32 renderTargetId, const TextureDesc& desc, const U8* buffer) {
+  UNUSED(renderTargetId);
+  UNUSED(desc);
+  UNUSED(buffer);
+}
+
 void VkRenderer::AddShader(const ShaderCreateInfo& info) {
   // TODO(vasumahesh1):[ASSETS]: Manage assets
   const String fullPath = "Shaders/" + VkRenderer::GetRenderingAPI() + "/" + info.m_shaderFileName;

--- a/Source/Samples/2_DeferredRenderer/Inc/App/Common.h
+++ b/Source/Samples/2_DeferredRenderer/Inc/App/Common.h
@@ -47,4 +47,10 @@ struct MeshObject
   U32 m_normalDataSize{0};
 };
 
+struct LightUBO
+{
+  float timeDelta{ 0.0f };
+  float _pad[3];
+};
+
 } // namespace Azura

--- a/Source/Samples/2_DeferredRenderer/Inc/Forward/ForwardComputeScene.h
+++ b/Source/Samples/2_DeferredRenderer/Inc/Forward/ForwardComputeScene.h
@@ -39,6 +39,7 @@ private:
   ForwardComputePass m_pass{};
   DrawablePool* m_mainPool{nullptr};
   ComputePool* m_computePool{nullptr};
+  LightTexture m_lightTexture;
 };
 
 } // namespace Azura

--- a/Source/Samples/2_DeferredRenderer/Shaders/Common.slang
+++ b/Source/Samples/2_DeferredRenderer/Shaders/Common.slang
@@ -49,7 +49,8 @@ struct Light {
 };
 
 struct LightUBO {
-  Light lights[NUM_LIGHTS];
+  float timeDelta;
+  float3 _pad;
 };
 
 float cubicGaussian(float h) {

--- a/Source/Samples/2_DeferredRenderer/Shaders/ForwardCompute.cs.slang
+++ b/Source/Samples/2_DeferredRenderer/Shaders/ForwardCompute.cs.slang
@@ -4,7 +4,12 @@ struct RWBlock {
     RWTexture2D<float4> rwTexture;
 };
 
-ParameterBlock<LightUBO> lightBlock;
+const static float LIGHT_DT = -2.5;
+const static float3 LIGHT_MIN = {-5.0, 0.0, -5.0 };
+const static float3 LIGHT_MAX = { 5.0, 15.0, 5.0 };
+
+
+ParameterBlock<LightUBO> lightUBO;
 ParameterBlock<RWBlock> rwBlock;
 
 const static int lightsPerThread = NUM_LIGHTS / 32;
@@ -15,11 +20,17 @@ void main(uint3 DTid : SV_DispatchThreadID)
     int offset = lightsPerThread * DTid.x;
 
     for(int idx = offset; idx < offset + lightsPerThread; ++idx) {
-        Light currentLight = lightBlock.lights[idx];
         float2 upper = float2(idx, 0);
         float2 lower = float2(idx, 1);
 
-        rwBlock.rwTexture[upper] = float4(currentLight.position, currentLight.radius);
-        rwBlock.rwTexture[lower] = float4(currentLight.color, 1.0);
+        float4 currentLightPosRad = rwBlock.rwTexture[upper];
+
+        currentLightPosRad.y += (LIGHT_DT * lightUBO.timeDelta);
+
+        if (currentLightPosRad.y < LIGHT_MIN.y) {
+            currentLightPosRad.y = LIGHT_MAX.y;
+        }
+
+        rwBlock.rwTexture[upper] = float4(currentLightPosRad.xyz, currentLightPosRad.w);
     }
 }


### PR DESCRIPTION
Changes:
fix: this allows us to update the light texture and upload it directly
to the GPU. This will have minimal bandwidth update between frame calls.

Modules:
D3D12RenderSystem
DeferredRenderer